### PR TITLE
Fix spacing in font export line

### DIFF
--- a/app/ui/fonts.ts
+++ b/app/ui/fonts.ts
@@ -2,7 +2,7 @@ import { Inter, Lusitana } from 'next/font/google';
 
 export const inter = Inter({ subsets: ['latin'] });
 
-export const lusitana  = Lusitana({
+export const lusitana = Lusitana({
   weight: ['400', '700'],
   subsets: ['latin']
 });


### PR DESCRIPTION
## Summary
- fix double-space in font export line

## Testing
- `pnpm lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867a04e4c20832ab8fcbfc1179c3757