### PR TITLE
Add generatePagination tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 
 # testing
 /coverage
+/dist-test
 
 # next.js
 /.next/

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
     "build": "next build",
     "dev": "next dev --turbopack",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test:compile": "tsc -p tsconfig.tests.json",
+    "test": "npm run test:compile && node --test ./dist-test/tests/utils.test.js"
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",

--- a/tests/node-test.d.ts
+++ b/tests/node-test.d.ts
@@ -1,0 +1,9 @@
+declare module 'node:test' {
+  const test: any;
+  export default test;
+}
+
+declare module 'node:assert/strict' {
+  const assert: any;
+  export = assert;
+}

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,0 +1,27 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { generatePagination } from '../app/lib/utils';
+
+// Total pages <= 7 should list all pages
+test('all pages displayed when total pages <= 7', () => {
+  assert.deepStrictEqual(generatePagination(1, 5), [1, 2, 3, 4, 5]);
+  assert.deepStrictEqual(generatePagination(4, 7), [1, 2, 3, 4, 5, 6, 7]);
+});
+
+// Current page near the start
+test('start pages include leading numbers and ellipsis', () => {
+  assert.deepStrictEqual(generatePagination(1, 8), [1, 2, 3, '...', 7, 8]);
+  assert.deepStrictEqual(generatePagination(3, 10), [1, 2, 3, '...', 9, 10]);
+});
+
+// Current page near the end
+test('end pages include trailing numbers and ellipsis', () => {
+  assert.deepStrictEqual(generatePagination(8, 8), [1, 2, '...', 6, 7, 8]);
+  assert.deepStrictEqual(generatePagination(9, 10), [1, 2, '...', 8, 9, 10]);
+});
+
+// Current page in the middle
+test('middle pages include surrounding numbers and ellipses', () => {
+  assert.deepStrictEqual(generatePagination(5, 10), [1, '...', 4, 5, 6, '...', 10]);
+  assert.deepStrictEqual(generatePagination(6, 11), [1, '...', 5, 6, 7, '...', 11]);
+});

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -1,0 +1,17 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "outDir": "dist-test",
+    "rootDir": ".",
+    "noEmit": false,
+    "target": "ES2017",
+    "allowJs": true,
+    "esModuleInterop": true
+  },
+  "include": [
+    "app/lib/utils.ts",
+    "tests/**/*"
+  ]
+}


### PR DESCRIPTION
## Summary
- add Node test config and ignore compiled output
- provide a Node-based test runner script
- cover edge cases for `generatePagination`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6867a05169e8832a87cdf55d370a6d95